### PR TITLE
Add Setting to set KEY_INFLATE_SIGNAL_STRENGTH_BOOL to false. This fixes signal bar stacking in some dualSIM configs.

### DIFF
--- a/app/src/main/java/me/ikirby/pixelutils/ConfigOverridesActivity.kt
+++ b/app/src/main/java/me/ikirby/pixelutils/ConfigOverridesActivity.kt
@@ -36,6 +36,7 @@ class ConfigOverridesActivity : Activity() {
         binding.btnOverrideWFC.setOnClickListener { overrideWFC() }
         binding.btnOverride5GSignalThreshold.setOnClickListener { override5GSignalThreshold() }
         binding.btnResetConfig.setOnClickListener { resetConfig() }
+        binding.btnSignalInflate.setOnClickListener { overrideSignalInflate() }
     }
 
     override fun onMenuItemSelected(featureId: Int, item: MenuItem): Boolean {
@@ -121,6 +122,12 @@ class ConfigOverridesActivity : Activity() {
                 CarrierConfigManager.KEY_5G_NR_SSRSRP_THRESHOLDS_INT_ARRAY,
                 intArrayOf(-115, -105, -95, -85)
             )
+        }
+        overrideConfig(overrides)
+    }
+    private fun overrideSignalInflate() {
+        val overrides = PersistableBundle().apply {
+            putBoolean(CarrierConfigManager.KEY_INFLATE_SIGNAL_STRENGTH_BOOL, false)
         }
         overrideConfig(overrides)
     }

--- a/app/src/main/res/layout/activity_config_overrides.xml
+++ b/app/src/main/res/layout/activity_config_overrides.xml
@@ -55,6 +55,13 @@
             android:textAllCaps="false" />
 
         <Button
+            android:id="@+id/btnSignalInflate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/signal_inflate"
+            android:textAllCaps="false" />
+
+        <Button
             android:id="@+id/btnResetConfig"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,5 @@
     <string name="reset_config">Reset to system default</string>
     <string name="override_notes">NOTE: These settings are NOT persistent and will be reset upon system reboot.</string>
     <string name="init_failed">Initialization failed</string>
+    <string name="signal_inflate">Disable Signal Inflate (5 bars to 4)</string>
 </resources>


### PR DESCRIPTION
Add Setting to set KEY_INFLATE_SIGNAL_STRENGTH_BOOL to false. This fixes signal bar stacking in some dualSIM configs. I only set it to false because I prefer 4 bars instead of 5, but I can modify this PR to also set the value to true if wanted/desired.