### PR TITLE
Add auto-apply reboot feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md — PixelCarrierSettings
+
+Project overview: [README.md](README.md)
+
+## Build & Run
+
+```bash
+./gradlew assembleDebug      # debug APK
+./gradlew assembleRelease    # ProGuard-optimized release APK
+./gradlew build              # full build with checks
+```
+
+- AGP 8.13.2, Kotlin 2.3.0, JVM target 1.8
+- compileSdk/targetSdk = 36, minSdk = 34
+
+## Architecture
+
+**Package**: `me.ikirby.pixelutils` — single flat package, ~350 LOC total.
+
+| Component | File | Role |
+|-----------|------|------|
+| MainActivity | [MainActivity.kt](app/src/main/java/me/ikirby/pixelutils/MainActivity.kt) | Dual-SIM VoLTE provisioning via Shizuku |
+| ConfigOverridesActivity | [ConfigOverridesActivity.kt](app/src/main/java/me/ikirby/pixelutils/ConfigOverridesActivity.kt) | Carrier config override presets |
+| InstrumentationHelper | [InstrumentationHelper.kt](app/src/main/java/me/ikirby/pixelutils/InstrumentationHelper.kt) | Instrumentation-based privilege elevation for `overrideConfig()` |
+
+## Key Patterns
+
+### Shizuku Permission Flow
+Always check `Shizuku.checkSelfPermission()` in `onStart()`. Call `init()` only after permission is granted. The app has no fallback — if Shizuku isn't running, show an error dialog and finish.
+
+### Hidden API Access
+```
+HiddenApiBypass.setHiddenApiExemptions("")
+```
+Accesses hidden APIs via `TelephonyFrameworkInitializer` + `ShizukuBinderWrapper`:
+- `ITelephony` → `setImsProvisioningInt()`, `resetIms()`
+- `ISub` → `getActiveSubscriptionInfoList()`, `getSlotIndex()`
+
+### Instrumentation-Based Config Override
+`ConfigOverridesActivity` starts `InstrumentationHelper` via `startInstrumentation()` to call `CarrierConfigManager.overrideConfig()` with shell-level permissions. The helper uses `startDelegateShellPermissionIdentity()` / `stopDelegateShellPermissionIdentity()` to temporarily elevate.
+
+### UI Binding
+ViewBinding everywhere — no `findViewById`. Layouts: `activity_main.xml` (two SIM sections, visibility toggled), `activity_config_overrides.xml` (button grid).
+
+## Conventions
+
+- Minimal, single-package structure — keep it flat
+- Toast + AlertDialog for user feedback
+- Prefer `PersistableBundle` for typed carrier config values
+- Version code = simple integer increment (current: 12)
+- Theme: `Theme.DeviceDefault.Settings`
+
+## Pitfalls
+
+1. **Shizuku is mandatory** — app crashes without it; always check permission before any privileged operation
+2. **Android 16 QPR2 Beta 3+**: `overrideConfig(persistent=true)` is blocked for non-system apps → overrides reset on reboot
+3. **No tests exist** — manual testing only; add tests before refactoring
+4. **Dual-SIM only** — UI hardcodes max 2 SIM slots
+5. **System theme dependency** — `Theme.DeviceDefault.Settings` may break on custom ROMs
+6. **Empty ProGuard rules** — relies entirely on AGP defaults; monitor release builds for missing keep rules
+7. **`init()` failure is fatal** — if `ITelephony`/`ISub` initialization fails, app shows error and exits

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Originally this app was made because I want to override specific configurations 
 
 From "Config overrides" menu, you can override carrier configurations (the same as what Pixel IMS does, but these are some presets). However, starting with Android 16 QPR2 Beta 3, calling `overrideConfig` with `persistent=true` is no longer possible for non-system apps, so these settings will be reset upon system reboot.
 
+**This app now supports auto-apply on reboot** — enable the toggle and all previously selected overrides are automatically re-applied in the background after every reboot. See [Auto-apply on reboot](#auto-apply-on-reboot) below for details.
+
 - **Enable VoLTE**: Sets `KEY_CARRIER_VOLTE_AVAILABLE_BOOL` to true, not needed if you use the Enable VoLTE option on the first screen.
 - **Enable NR(5G) SA**: Sets `KEY_CARRIER_NR_AVAILABILITIES_INT_ARRAY` to `[1, 2]` which enables both NSA and SA.
 - **Enable VoNR(Vo5G)**: Sets `KEY_VONR_ENABLED_BOOL` and `KEY_VONR_SETTING_VISIBILITY_BOOL` to true. VoNR lets the device stay connected to 5G when calling instead of switching to LTE.
@@ -34,6 +36,36 @@ From "Config overrides" menu, you can override carrier configurations (the same 
 - **Show IMS status in SIM status**: Sets `KEY_SHOW_IMS_REGISTRATION_STATUS_BOOL` to true. This adds `IMS registration state` to About phone - SIM status. Android 16 QPR3 Beta 1 has a bug which crashes `com.android.phone` when opening PhoneInformation or PhoneInformationV2 test menu. This option allows seeing IMS status without going to the menu.
 
 If you need manual/custom overrides, please check out [Pixel IMS](https://github.com/kyujin-cho/pixel-volte-patch).
+
+## Auto-apply on reboot
+
+Since Android 16 QPR2 Beta 3 blocks `overrideConfig(persistent=true)` for non-system apps, carrier config overrides are lost after every reboot. This app solves that by listening for system boot events and re-applying your saved overrides in the background via Shizuku.
+
+### How to use
+
+1. Turn on the **"Auto-apply configs on reboot"** switch on the main screen
+2. Use Config Overrides normally — each selection is automatically remembered per SIM card (keyed by ICCID)
+3. Reboot your device; the app will re-apply all saved overrides without you having to open it
+
+> **Prerequisite**: Shizuku must be running after reboot. If it isn't yet, the app retries with exponential backoff (starting at 10 seconds) until Shizuku becomes available. Even if your SIM has a PIN lock, the app waits for the SIM to become ready before applying.
+
+### How it works
+
+**Persistence** (`ConfigStateManager`)
+- Stores applied override flags per SIM in SharedPreferences, keyed by ICCID so configs survive subId changes across reboots
+- Global toggle controls whether auto-apply is enabled
+
+**Boot trigger** (`BootReceiver`)
+- Registers for `BOOT_COMPLETED` broadcast; enqueues a WorkManager worker when the device finishes booting
+
+**SIM PIN delay handling** (`SimStateReceiver`)
+- Listens for `SIM_STATE_CHANGED` broadcasts; when the SIM transitions to `LOADED` (PIN entered), immediately fires the worker instead of waiting for the next backoff interval
+
+**Background execution** (`AutoApplyWorker` — WorkManager)
+- Obtains the current subscription list through Shizuku (`ISub`), matches each SIM by ICCID against saved configs
+- Launches `InstrumentationHelper` via `startInstrumentation()` to gain shell-level permissions for `CarrierConfigManager.overrideConfig()`
+- Batches all overrides for a single SIM into one instrumentation call for efficiency
+- Retries with exponential backoff (initial 10 s, up to ~5 hours between attempts) so configs are applied within a minute of Shizuku becoming available
 
 ## References
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,4 +48,5 @@ dependencies {
     implementation(libs.shizuku.api)
     implementation(libs.shizuku.provider)
     implementation(libs.hiddenapibypass)
+    implementation(libs.work.runtime.ktx)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -28,6 +30,22 @@
             android:exported="true"
             android:multiprocess="false"
             android:permission="android.permission.INTERACT_ACROSS_USERS_FULL" />
+
+        <receiver
+            android:name=".BootReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
+            android:name=".SimStateReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.SIM_STATE_CHANGED" />
+            </intent-filter>
+        </receiver>
     </application>
 
     <instrumentation

--- a/app/src/main/java/me/ikirby/pixelutils/AutoApplyWorker.kt
+++ b/app/src/main/java/me/ikirby/pixelutils/AutoApplyWorker.kt
@@ -1,0 +1,157 @@
+package me.ikirby.pixelutils
+
+import android.content.Context
+import android.os.PersistableBundle
+import android.telephony.CarrierConfigManager
+import android.telephony.TelephonyFrameworkInitializer
+import android.util.Log
+import androidx.work.BackoffPolicy
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.android.internal.telephony.ISub
+import org.lsposed.hiddenapibypass.HiddenApiBypass
+import rikka.shizuku.ShizukuBinderWrapper
+import java.util.concurrent.TimeUnit
+
+/**
+ * WorkManager worker that applies saved carrier config overrides in the background
+ * after device boot. Retries with exponential backoff if Shizuku or the SIM is not
+ * yet ready.
+ */
+class AutoApplyWorker(
+    context: Context,
+    params: WorkerParameters
+) : CoroutineWorker(context, params) {
+
+    companion object {
+        private const val TAG = "PixelCS.AutoApply"
+        private const val UNIQUE_WORK_NAME = "auto_apply_configs"
+
+        /** Enqueue (or replace) the auto-apply work. Safe to call from any thread. */
+        fun enqueue(context: Context) {
+            val request = OneTimeWorkRequestBuilder<AutoApplyWorker>()
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 10, TimeUnit.SECONDS)
+                .build()
+            WorkManager.getInstance(context.applicationContext)
+                .enqueueUniqueWork(UNIQUE_WORK_NAME, ExistingWorkPolicy.REPLACE, request)
+            Log.d(TAG, "Work enqueued")
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        Log.d(TAG, "doWork() started")
+        ConfigStateManager.init(applicationContext)
+
+        // 1. Load saved configs; nothing to do if none are saved
+        val allConfigs = ConfigStateManager.getAllConfigs()
+        Log.d(TAG, "Saved configs: ${allConfigs.size} ICCIDs")
+        if (allConfigs.isEmpty()) {
+            Log.i(TAG, "No saved configs, finishing")
+            return Result.success()
+        }
+
+        // 2. Ensure hidden API access is available (may not have been called yet)
+        HiddenApiBypass.setHiddenApiExemptions("")
+
+        // 3. Obtain ISub binder via Shizuku
+        val sub: ISub = try {
+            val binder = TelephonyFrameworkInitializer
+                .getTelephonyServiceManager()
+                .subscriptionServiceRegisterer
+                .get()
+            if (binder == null) {
+                Log.w(TAG, "Shizuku binder not available, retrying")
+                return Result.retry()
+            }
+            ISub.Stub.asInterface(ShizukuBinderWrapper(binder))
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to get ISub binder", e)
+            return Result.retry()
+        }
+
+        // 4. Get current subscriptions
+        val subscriptions = try {
+            sub.getActiveSubscriptionInfoList(null, null, false)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to get subscription list", e)
+            return Result.retry()
+        }
+        Log.d(TAG, "Active subscriptions: ${subscriptions.size}")
+        if (subscriptions.isEmpty()) {
+            Log.w(TAG, "No active subscriptions, retrying (SIM may need PIN)")
+            return Result.retry()
+        }
+
+        // 5. Apply saved configs for each SIM matched by ICCID
+        var applied = 0
+        for (subInfo in subscriptions) {
+            val iccid = subInfo.iccId ?: continue
+            val savedKeys = allConfigs[iccid] ?: continue
+            Log.d(TAG, "Applying ${savedKeys.size} config(s) for ICCID=${iccid.takeLast(4)}")
+
+            val overridesList = savedKeys.mapNotNull { key -> buildOverrides(key) }
+            if (overridesList.isEmpty()) continue
+
+            try {
+                CarrierConfigHelper.applyViaInstrumentation(
+                    applicationContext, subInfo.subscriptionId, overridesList
+                )
+                applied += overridesList.size
+                Log.d(TAG, "Applied ${overridesList.size} config(s) for subId=${subInfo.subscriptionId}")
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to apply configs for subId=${subInfo.subscriptionId}", e)
+            }
+        }
+
+        Log.i(TAG, "Finished: applied $applied config(s)")
+        return Result.success()
+    }
+
+    /** Build a [PersistableBundle] for the given config key. */
+    private fun buildOverrides(key: ConfigStateManager.ConfigKey): PersistableBundle? {
+        return when (key) {
+            ConfigStateManager.ConfigKey.VOLTE -> PersistableBundle().apply {
+                putBoolean(CarrierConfigManager.KEY_CARRIER_VOLTE_AVAILABLE_BOOL, true)
+            }
+            ConfigStateManager.ConfigKey.VONR -> PersistableBundle().apply {
+                putBoolean(CarrierConfigManager.KEY_VONR_ENABLED_BOOL, true)
+                putBoolean(CarrierConfigManager.KEY_VONR_SETTING_VISIBILITY_BOOL, true)
+            }
+            ConfigStateManager.ConfigKey.NR_MODE -> PersistableBundle().apply {
+                putIntArray(
+                    CarrierConfigManager.KEY_CARRIER_NR_AVAILABILITIES_INT_ARRAY,
+                    intArrayOf(
+                        CarrierConfigManager.CARRIER_NR_AVAILABILITY_NSA,
+                        CarrierConfigManager.CARRIER_NR_AVAILABILITY_SA
+                    )
+                )
+            }
+            ConfigStateManager.ConfigKey.WFC -> PersistableBundle().apply {
+                putBoolean(CarrierConfigManager.KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL, true)
+                putBoolean(CarrierConfigManager.KEY_CARRIER_WFC_SUPPORTS_WIFI_ONLY_BOOL, true)
+                putBoolean(CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_ROAMING_ENABLED_BOOL, true)
+                putBoolean(CarrierConfigManager.KEY_EDITABLE_WFC_MODE_BOOL, true)
+                putBoolean(CarrierConfigManager.KEY_EDITABLE_WFC_ROAMING_MODE_BOOL, true)
+                putInt(CarrierConfigManager.KEY_WFC_SPN_FORMAT_IDX_INT, 4)
+            }
+            ConfigStateManager.ConfigKey.SIGNAL_THRESHOLD -> PersistableBundle().apply {
+                putIntArray(
+                    CarrierConfigManager.KEY_5G_NR_SSRSRP_THRESHOLDS_INT_ARRAY,
+                    intArrayOf(-115, -105, -95, -85)
+                )
+            }
+            ConfigStateManager.ConfigKey.SIGNAL_INFLATE -> PersistableBundle().apply {
+                putBoolean(CarrierConfigManager.KEY_INFLATE_SIGNAL_STRENGTH_BOOL, false)
+            }
+            ConfigStateManager.ConfigKey.SHOW_IMS -> PersistableBundle().apply {
+                putBoolean(CarrierConfigManager.KEY_SHOW_IMS_REGISTRATION_STATUS_BOOL, true)
+            }
+            ConfigStateManager.ConfigKey.SHOW_4G -> PersistableBundle().apply {
+                putBoolean(CarrierConfigManager.KEY_SHOW_4G_FOR_LTE_DATA_ICON_BOOL, true)
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/ikirby/pixelutils/BootReceiver.kt
+++ b/app/src/main/java/me/ikirby/pixelutils/BootReceiver.kt
@@ -1,0 +1,28 @@
+package me.ikirby.pixelutils
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+/**
+ * Triggers auto-apply of saved carrier config overrides after device boot completes.
+ */
+class BootReceiver : BroadcastReceiver() {
+    companion object {
+        private const val TAG = "PixelCS.BootReceiver"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        Log.d(TAG, "Received: ${intent.action}")
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+
+        ConfigStateManager.init(context)
+        val enabled = ConfigStateManager.isAutoApplyEnabled
+        Log.d(TAG, "Auto-apply enabled=$enabled")
+
+        if (!enabled) return
+        AutoApplyWorker.enqueue(context)
+        Log.i(TAG, "AutoApplyWorker enqueued")
+    }
+}

--- a/app/src/main/java/me/ikirby/pixelutils/CarrierConfigHelper.kt
+++ b/app/src/main/java/me/ikirby/pixelutils/CarrierConfigHelper.kt
@@ -1,0 +1,78 @@
+package me.ikirby.pixelutils
+
+import android.annotation.SuppressLint
+import android.app.ActivityManager
+import android.app.IActivityManager
+import android.app.UiAutomationConnection
+import android.content.ComponentName
+import android.content.Context
+import android.os.Bundle
+import android.os.PersistableBundle
+import android.os.ServiceManager
+import android.system.Os
+import android.telephony.CarrierConfigManager
+import rikka.shizuku.ShizukuBinderWrapper
+
+/**
+ * Shared utility for applying carrier config overrides with shell-level permissions
+ * via Shizuku. Used by both the UI-triggered [InstrumentationHelper] flow and the
+ * background [AutoApplyWorker].
+ */
+object CarrierConfigHelper {
+
+    /**
+     * Apply (or reset) a carrier config override for the given subscription.
+     * **Must be called from within an instrumentation context** (i.e. inside
+     * [InstrumentationHelper]) — otherwise use [applyViaInstrumentation].
+     *
+     * @param context  Application or activity context.
+     * @param subId    Subscription ID to override.
+     * @param overrides [PersistableBundle] of key-value pairs, or `null` to reset.
+     */
+    @SuppressLint("MissingPermission")
+    fun applyOverrideConfig(context: Context, subId: Int, overrides: PersistableBundle?) {
+        val ams = IActivityManager.Stub.asInterface(
+            ShizukuBinderWrapper(ServiceManager.getService(Context.ACTIVITY_SERVICE))
+        )
+        ams.startDelegateShellPermissionIdentity(Os.getuid(), null)
+        try {
+            val ccm = context.applicationContext
+                .getSystemService(CarrierConfigManager::class.java)
+            ccm.overrideConfig(subId, overrides, /* persistent = */ false)
+        } finally {
+            ams.stopDelegateShellPermissionIdentity()
+        }
+    }
+
+    /**
+     * Apply carrier config overrides from a non-instrumentation context (e.g. a
+     * [androidx.work.Worker]). Launches [InstrumentationHelper] via Shizuku to gain
+     * shell-level permissions. Batches all overrides for one subId into a single
+     * instrumentation launch.
+     *
+     * @param context       Application or activity context (used for package name).
+     * @param subId         Subscription ID to override.
+     * @param overridesList List of [PersistableBundle] overrides to apply.
+     */
+    fun applyViaInstrumentation(context: Context, subId: Int, overridesList: List<PersistableBundle>) {
+        if (overridesList.isEmpty()) return
+        val subIds = IntArray(overridesList.size) { subId }
+        val args = Bundle().apply {
+            putIntArray("subIds", subIds)
+            putParcelableArrayList("overridesList", ArrayList(overridesList))
+        }
+        val ams = IActivityManager.Stub.asInterface(
+            ShizukuBinderWrapper(ServiceManager.getService(Context.ACTIVITY_SERVICE))
+        )
+        ams.startInstrumentation(
+            ComponentName(context.applicationContext, InstrumentationHelper::class.java),
+            null,
+            ActivityManager.INSTR_FLAG_NO_RESTART,
+            args,
+            null,
+            UiAutomationConnection(),
+            0,
+            null
+        )
+    }
+}

--- a/app/src/main/java/me/ikirby/pixelutils/ConfigOverridesActivity.kt
+++ b/app/src/main/java/me/ikirby/pixelutils/ConfigOverridesActivity.kt
@@ -19,6 +19,7 @@ class ConfigOverridesActivity : Activity() {
     private lateinit var binding: ActivityConfigOverridesBinding
 
     private var subId = 0
+    private var iccid = ""
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -27,6 +28,7 @@ class ConfigOverridesActivity : Activity() {
         setContentView(binding.root)
 
         subId = intent.getIntExtra("subId", 0)
+        iccid = intent.getStringExtra("iccid") ?: ""
         title = intent.getStringExtra("displayName") ?: ""
         actionBar?.setDisplayHomeAsUpEnabled(true)
 
@@ -50,11 +52,10 @@ class ConfigOverridesActivity : Activity() {
         Toast.makeText(this, resId, Toast.LENGTH_SHORT).show()
     }
 
-    private fun overrideConfig(overrides: PersistableBundle?) {
+    private fun overrideConfig(overrides: PersistableBundle?, key: ConfigStateManager.ConfigKey? = null) {
         val args = Bundle().apply {
             putInt("subId", subId)
             putParcelable("overrides", overrides)
-            putBoolean("persistent", false)
         }
         val ams = IActivityManager.Stub.asInterface(
             ShizukuBinderWrapper(ServiceManager.getService(ACTIVITY_SERVICE))
@@ -70,8 +71,10 @@ class ConfigOverridesActivity : Activity() {
             null
         )
         if (overrides == null) {
+            if (iccid.isNotEmpty()) ConfigStateManager.clearConfigs(iccid)
             showToast(R.string.config_reset)
         } else {
+            if (iccid.isNotEmpty() && key != null) ConfigStateManager.markConfigApplied(iccid, key)
             showToast(R.string.config_updated)
         }
     }
@@ -84,14 +87,14 @@ class ConfigOverridesActivity : Activity() {
         val overrides = PersistableBundle().apply {
             putBoolean(CarrierConfigManager.KEY_CARRIER_VOLTE_AVAILABLE_BOOL, true)
         }
-        overrideConfig(overrides)
+        overrideConfig(overrides, ConfigStateManager.ConfigKey.VOLTE)
     }
 
     private fun overrideShowIMSStatus() {
         val overrides = PersistableBundle().apply {
             putBoolean(CarrierConfigManager.KEY_SHOW_IMS_REGISTRATION_STATUS_BOOL, true)
         }
-        overrideConfig(overrides)
+        overrideConfig(overrides, ConfigStateManager.ConfigKey.SHOW_IMS)
     }
 
     private fun overrideVoNR() {
@@ -99,7 +102,7 @@ class ConfigOverridesActivity : Activity() {
             putBoolean(CarrierConfigManager.KEY_VONR_ENABLED_BOOL, true)
             putBoolean(CarrierConfigManager.KEY_VONR_SETTING_VISIBILITY_BOOL, true)
         }
-        overrideConfig(overrides)
+        overrideConfig(overrides, ConfigStateManager.ConfigKey.VONR)
     }
 
     private fun overrideNRMode() {
@@ -112,7 +115,7 @@ class ConfigOverridesActivity : Activity() {
                 )
             )
         }
-        overrideConfig(overrides)
+        overrideConfig(overrides, ConfigStateManager.ConfigKey.NR_MODE)
     }
 
     private fun overrideWFC() {
@@ -124,7 +127,7 @@ class ConfigOverridesActivity : Activity() {
             putBoolean(CarrierConfigManager.KEY_EDITABLE_WFC_ROAMING_MODE_BOOL, true)
             putInt(CarrierConfigManager.KEY_WFC_SPN_FORMAT_IDX_INT, 4)
         }
-        overrideConfig(overrides)
+        overrideConfig(overrides, ConfigStateManager.ConfigKey.WFC)
     }
 
     private fun override5GSignalThreshold() {
@@ -134,20 +137,20 @@ class ConfigOverridesActivity : Activity() {
                 intArrayOf(-115, -105, -95, -85)
             )
         }
-        overrideConfig(overrides)
+        overrideConfig(overrides, ConfigStateManager.ConfigKey.SIGNAL_THRESHOLD)
     }
 
     private fun overrideSignalInflate() {
         val overrides = PersistableBundle().apply {
             putBoolean(CarrierConfigManager.KEY_INFLATE_SIGNAL_STRENGTH_BOOL, false)
         }
-        overrideConfig(overrides)
+        overrideConfig(overrides, ConfigStateManager.ConfigKey.SIGNAL_INFLATE)
     }
 
     private fun overrideShow4G() {
         val overrides = PersistableBundle().apply {
             putBoolean(CarrierConfigManager.KEY_SHOW_4G_FOR_LTE_DATA_ICON_BOOL, true)
         }
-        overrideConfig(overrides)
+        overrideConfig(overrides, ConfigStateManager.ConfigKey.SHOW_4G)
     }
 }

--- a/app/src/main/java/me/ikirby/pixelutils/ConfigStateManager.kt
+++ b/app/src/main/java/me/ikirby/pixelutils/ConfigStateManager.kt
@@ -1,0 +1,88 @@
+package me.ikirby.pixelutils
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+
+/**
+ * Manages persistent state of which carrier config overrides have been applied per SIM,
+ * plus the global auto-apply-on-boot toggle.
+ *
+ * Each SIM is keyed by ICCID so configs survive subId changes across reboots.
+ */
+object ConfigStateManager {
+
+    private const val TAG = "PixelCS.ConfigState"
+    private const val PREFS_NAME = "config_state"
+    private const val KEY_AUTO_APPLY = "auto_apply_enabled"
+    private const val PREFIX_CONFIG = "cfg_"
+
+    private var prefs: SharedPreferences? = null
+
+    fun init(context: Context) {
+        if (prefs == null) {
+            prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            Log.d(TAG, "Initialized, autoApply=${isAutoApplyEnabled}")
+        }
+    }
+
+    private fun requirePrefs(): SharedPreferences = prefs
+        ?: throw IllegalStateException("ConfigStateManager not initialized. Call init() first.")
+
+    /** Global toggle: should saved configs be automatically applied after boot? */
+    var isAutoApplyEnabled: Boolean
+        get() = requirePrefs().getBoolean(KEY_AUTO_APPLY, false)
+        set(value) = requirePrefs().edit().putBoolean(KEY_AUTO_APPLY, value).apply()
+
+    /** Mark a specific config key as applied for the given ICCID. */
+    fun markConfigApplied(iccid: String, key: ConfigKey) {
+        val current = getAppliedConfigNames(iccid).toMutableSet()
+        current.add(key.name)
+        requirePrefs().edit().putStringSet(configKey(iccid), current).apply()
+    }
+
+    /** Get the set of config keys saved for the given ICCID. */
+    fun getAppliedConfigs(iccid: String): Set<ConfigKey> {
+        return getAppliedConfigNames(iccid).mapNotNull { name ->
+            try { ConfigKey.valueOf(name) } catch (_: IllegalArgumentException) { null }
+        }.toSet()
+    }
+
+    /** Returns all saved configs grouped by ICCID. */
+    fun getAllConfigs(): Map<String, Set<ConfigKey>> {
+        val all = requirePrefs().all
+        val result = mutableMapOf<String, Set<ConfigKey>>()
+        for ((key, _) in all) {
+            if (key.startsWith(PREFIX_CONFIG)) {
+                val iccid = key.removePrefix(PREFIX_CONFIG)
+                val configs = getAppliedConfigs(iccid)
+                if (configs.isNotEmpty()) {
+                    result[iccid] = configs
+                }
+            }
+        }
+        return result
+    }
+
+    /** Clear all saved configs for the given ICCID (e.g. after reset). */
+    fun clearConfigs(iccid: String) {
+        requirePrefs().edit().remove(configKey(iccid)).apply()
+    }
+
+    private fun getAppliedConfigNames(iccid: String): Set<String> {
+        return requirePrefs().getStringSet(configKey(iccid), emptySet()) ?: emptySet()
+    }
+
+    private fun configKey(iccid: String) = "$PREFIX_CONFIG$iccid"
+
+    enum class ConfigKey {
+        VOLTE,
+        VONR,
+        NR_MODE,
+        WFC,
+        SIGNAL_THRESHOLD,
+        SIGNAL_INFLATE,
+        SHOW_IMS,
+        SHOW_4G
+    }
+}

--- a/app/src/main/java/me/ikirby/pixelutils/InstrumentationHelper.kt
+++ b/app/src/main/java/me/ikirby/pixelutils/InstrumentationHelper.kt
@@ -1,15 +1,8 @@
 package me.ikirby.pixelutils
 
-import android.annotation.SuppressLint
-import android.app.IActivityManager
 import android.app.Instrumentation
-import android.content.Context
 import android.os.Bundle
 import android.os.PersistableBundle
-import android.os.ServiceManager
-import android.system.Os
-import android.telephony.CarrierConfigManager
-import rikka.shizuku.ShizukuBinderWrapper
 
 class InstrumentationHelper : Instrumentation() {
 
@@ -19,24 +12,26 @@ class InstrumentationHelper : Instrumentation() {
             finish(0, null)
             return
         }
+
+        // Batch mode: "subIds" (int[]) + "overridesList" (ArrayList<PersistableBundle>)
+        val subIds = arguments.getIntArray("subIds")
+        if (subIds != null) {
+            val overridesList = arguments.getParcelableArrayList<PersistableBundle>("overridesList")
+            if (overridesList != null && subIds.size == overridesList.size) {
+                for (i in subIds.indices) {
+                    CarrierConfigHelper.applyOverrideConfig(
+                        context, subIds[i], overridesList[i]
+                    )
+                }
+            }
+            finish(0, null)
+            return
+        }
+
+        // Single mode (backward-compatible with ConfigOverridesActivity)
         val subId = arguments.getInt("subId", 0)
         val overrides = arguments.getParcelable("overrides", PersistableBundle::class.java)
-        val persistent = arguments.getBoolean("persistent", false)
-        overrideConfig(subId, overrides, persistent)
-    }
-
-    @SuppressLint("MissingPermission")
-    private fun overrideConfig(subId: Int, overrides: PersistableBundle?, persistent: Boolean) {
-        val ams = IActivityManager.Stub.asInterface(
-            ShizukuBinderWrapper(ServiceManager.getService(Context.ACTIVITY_SERVICE))
-        )
-        ams.startDelegateShellPermissionIdentity(Os.getuid(), null)
-        try {
-            val ccm = context.getSystemService(CarrierConfigManager::class.java)
-            ccm.overrideConfig(subId, overrides, persistent)
-        } finally {
-            ams.stopDelegateShellPermissionIdentity()
-        }
+        CarrierConfigHelper.applyOverrideConfig(context, subId, overrides)
         finish(0, null)
     }
 }

--- a/app/src/main/java/me/ikirby/pixelutils/MainActivity.kt
+++ b/app/src/main/java/me/ikirby/pixelutils/MainActivity.kt
@@ -25,6 +25,8 @@ class MainActivity : Activity() {
     private lateinit var sub: ISub
     private var subIdPhone0 = 0
     private var subIdPhone1 = 0
+    private var iccid0 = ""
+    private var iccid1 = ""
 
     private val shizukuPermissionListener =
         OnRequestPermissionResultListener { _, grantResult ->
@@ -39,9 +41,14 @@ class MainActivity : Activity() {
         super.onCreate(savedInstanceState)
 
         HiddenApiBypass.setHiddenApiExemptions("")
+        ConfigStateManager.init(this)
 
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        binding.switchAutoApply.setOnCheckedChangeListener { _, isChecked ->
+            ConfigStateManager.isAutoApplyEnabled = isChecked
+        }
 
         binding.btnEnableIMS0.setOnClickListener { enableIMSProvisioning(subIdPhone0) }
         binding.btnResetIMS0.setOnClickListener { resetIMS(subIdPhone0) }
@@ -49,6 +56,7 @@ class MainActivity : Activity() {
             val intent = Intent(this, ConfigOverridesActivity::class.java).apply {
                 putExtra("subId", subIdPhone0)
                 putExtra("displayName", binding.textNameSub0.text.toString())
+                putExtra("iccid", iccid0)
             }
             startActivity(intent)
         }
@@ -60,6 +68,7 @@ class MainActivity : Activity() {
             val intent = Intent(this, ConfigOverridesActivity::class.java).apply {
                 putExtra("subId", subIdPhone1)
                 putExtra("displayName", binding.textNameSub1.text.toString())
+                putExtra("iccid", iccid1)
             }
             startActivity(intent)
         }
@@ -70,6 +79,7 @@ class MainActivity : Activity() {
 
     override fun onStart() {
         super.onStart()
+        binding.switchAutoApply.isChecked = ConfigStateManager.isAutoApplyEnabled
         checkShizukuPermission()
     }
 
@@ -172,6 +182,7 @@ class MainActivity : Activity() {
 
         val first = subscriptions[0]
         subIdPhone0 = first.subscriptionId
+        iccid0 = first.iccId ?: ""
         binding.textNameSub0.text = first.displayName
         binding.layoutSub0.visibility = View.VISIBLE
 
@@ -181,6 +192,7 @@ class MainActivity : Activity() {
             return
         }
         subIdPhone1 = second.subscriptionId
+        iccid1 = second.iccId ?: ""
         binding.textNameSub1.text = second.displayName
         binding.layoutSub1.visibility = View.VISIBLE
     }

--- a/app/src/main/java/me/ikirby/pixelutils/SimStateReceiver.kt
+++ b/app/src/main/java/me/ikirby/pixelutils/SimStateReceiver.kt
@@ -1,0 +1,35 @@
+package me.ikirby.pixelutils
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.telephony.TelephonyManager
+import android.util.Log
+
+/**
+ * Listens for SIM state changes. When the SIM becomes LOADED (e.g. after the user
+ * enters the SIM PIN), immediately triggers auto-apply instead of waiting for the
+ * WorkManager retry backoff.
+ */
+class SimStateReceiver : BroadcastReceiver() {
+    companion object {
+        private const val TAG = "PixelCS.SimStateRcvr"
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_SIM_STATE_CHANGED) return
+        val simState = intent.getIntExtra(TelephonyManager.EXTRA_SIM_STATE, TelephonyManager.SIM_STATE_UNKNOWN)
+        Log.d(TAG, "SIM state changed: $simState (LOADED=${TelephonyManager.SIM_STATE_LOADED})")
+
+        if (simState != TelephonyManager.SIM_STATE_LOADED) return
+
+        ConfigStateManager.init(context)
+        val enabled = ConfigStateManager.isAutoApplyEnabled
+        Log.d(TAG, "Auto-apply enabled=$enabled")
+
+        if (!enabled) return
+        AutoApplyWorker.enqueue(context)
+        Log.i(TAG, "AutoApplyWorker enqueued (SIM loaded)")
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -13,6 +13,28 @@
         android:padding="16dp">
 
         <LinearLayout
+            android:id="@+id/layoutAutoApply"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="12dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/auto_apply_title"
+                android:textColor="?android:textColorPrimary"
+                android:textSize="16sp" />
+
+            <Switch
+                android:id="@+id/switchAutoApply"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <LinearLayout
             android:id="@+id/layoutSub0"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,4 +24,6 @@
     <string name="signal_inflate">Disable Signal Inflate (5 bars to 4)</string>
     <string name="show_ims_status">Show IMS status in SIM status</string>
     <string name="show_4g_instead">Show 4G instead of LTE</string>
+    <string name="auto_apply_title">Auto-apply configs on reboot</string>
+    <string name="auto_apply_summary">Saved overrides are automatically re-applied after system reboot</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,11 +3,13 @@ agp = "8.13.2"
 kotlin = "2.3.0"
 shizuku = "13.1.5"
 hiddenapibypass = "6.1"
+work = "2.10.0"
 
 [libraries]
 shizuku-api = { group = "dev.rikka.shizuku", name = "api", version.ref = "shizuku" }
 shizuku-provider = { group = "dev.rikka.shizuku", name = "provider", version.ref = "shizuku" }
 hiddenapibypass = { group = "org.lsposed.hiddenapibypass", name = "hiddenapibypass", version.ref = "hiddenapibypass" }
+work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
If Shizuku service is in root mode, this change can auto apply the settings after phone reboot. Even if shizuku is in wireless adb debug mode, by right after phone reboot you can turn on phone's wireless hot spot, start shizuku service and this app will auto apply the saved settings after retry (though I never tested this scenario). 